### PR TITLE
Pubsub new trigger mechanism

### DIFF
--- a/test/specs/trait/pubsub.js
+++ b/test/specs/trait/pubsub.js
@@ -258,6 +258,20 @@ define(['real/trait/pubsub', 'nbd/util/extend'], function(pubsub, extend) {
         expect(cb.calls.count()).toEqual(1);
       });
 
+      it("removes all events mid-fire", function() {
+        spy.and.callFake(function() {
+          obj.off();
+        });
+        obj.on('event', spy);
+
+        expect(function() {
+          obj.trigger('event');
+          obj.trigger('event');
+        }).not.toThrow();
+
+        expect(spy.calls.count()).toEqual(1);
+      });
+
       it("does not skip consecutive events", function() {
         obj.on('event', function() { throw new Error(); }, obj);
         obj.on('event', function() { throw new Error(); }, obj);

--- a/test/specs/trait/pubsub.js
+++ b/test/specs/trait/pubsub.js
@@ -101,6 +101,14 @@ define(['real/trait/pubsub', 'nbd/util/extend'], function(pubsub, extend) {
         obj.trigger('fool');
       });
 
+      it('triggers when bound inside a callback', function(done) {
+        obj.one('fool', function() {
+          obj.one('fool', done);
+          obj.trigger('fool');
+        });
+        obj.trigger('fool');
+      });
+
       it('does not stop other bound callbacks from firing', function() {
         var spy2 = jasmine.createSpy();
         obj.one('event', spy);


### PR DESCRIPTION
Mechanism relied on array filtering on the trigger side to remove called
entries marked as `once`. This has been replaced with an in-place
removal of the entry. Additionally, the event attaching side concats to
a new array instead of pushes to the existing one in order to avoid
mid-callback modifications to the array.