### PR TITLE
trait/pubsub: all event .one removes wrong entry

### DIFF
--- a/test/specs/trait/pubsub.js
+++ b/test/specs/trait/pubsub.js
@@ -118,6 +118,13 @@ define(['real/trait/pubsub', 'nbd/util/extend'], function(pubsub, extend) {
         expect(spy2.calls.count()).toBe(1);
       });
 
+      it('unbinds from the `all` special event', function() {
+        obj.one('all', spy);
+        obj.trigger('event');
+        obj.trigger('event');
+        expect(spy.calls.count()).toBe(1);
+      });
+
       it("if no callback is provided, `one` is a noop", function() {
         obj.one('test').trigger('test');
       });

--- a/trait/pubsub.js
+++ b/trait/pubsub.js
@@ -109,7 +109,7 @@ define(['../util/curry'], function(curry) {
       if (all) {
         for (index = 0; entry = all[index]; ++index) {
           if (entry.once) {
-            events.splice(index--, 1);
+            all.splice(index--, 1);
           }
           entry.fn.apply(entry.ctxt || entry.self, arguments);
         }


### PR DESCRIPTION
The splice is being called on the wrong array.