### PR TITLE
Model: change detection fails for modify-in-callback

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -19,8 +19,8 @@ define([
   }
 
   var dirtyCheck = function(old, novel) {
-    diff.call(this, novel || this._data, old, this.trigger);
     this._dirty = 0;
+    diff.call(this, novel || this._data, old, this.trigger);
   },
 
   constructor = Class.extend({

--- a/test/specs/Model.js
+++ b/test/specs/Model.js
@@ -267,6 +267,24 @@ define(['real/Model', 'nbd/Class'], function(Model, Class) {
             done();
           }, t);
         });
+
+        it('can mix calls to .set() during event callback', function(done) {
+          instance.on('foo', cb.and.callFake(function() {
+            instance.set('id', 24601);
+          }));
+
+          var spy = jasmine.createSpy('chained spy');
+          instance.on('id', spy);
+
+          instance.set('foo', 'baz');
+
+          setTimeout(function() {
+            expect(cb.calls.count()).toBe(1);
+            expect(cb).toHaveBeenCalledWith('baz', 'bar');
+            expect(spy).toHaveBeenCalledWith(24601, undefined);
+            done();
+          }, t);
+        });
       });
     });
 


### PR DESCRIPTION
When the model is being modified mid-callback, change detection
mechanism assumes the current state is consistent and thus never
registers another change detection.