### PR TITLE
View: make browser not required at import

### DIFF
--- a/View.js
+++ b/View.js
@@ -4,8 +4,19 @@ define([
 ], function(Class, pubsub) {
   "use strict";
 
-  var shadow = document.createDocumentFragment(),
-  renderMatching = function(key) {
+  // `getShadow` ensures that this file can be statically imported
+  // in environments where document is not defined. this is useful
+  // for ergonomics in isomorphic components where only a certain
+  // phase of the component is rendered on the browser.
+  var shadow;
+  var lazyGetShadow = function() {
+    if (!shadow) {
+      shadow = document.createDocumentFragment();
+    }
+    return shadow;
+  };
+
+  var renderMatching = function(key) {
     if (!this.$view) { return; }
     var selector = this.nests[key],
     contained = this._model.get ? this._model.get(key) : this._model[key],
@@ -90,7 +101,7 @@ define([
 
     _switchNested: function(key, val, old) {
       if (this.nests != null && key in this.nests) {
-        if (old && old.render) { old.render(shadow); }
+        if (old && old.render) { old.render(lazyGetShadow()); }
         renderMatching.call(this, key);
       }
     }


### PR DESCRIPTION
This change is motivated by the desire to statically import `View` into an isomorphic component, where `View` is used in the mounted (browser-only) phase. This is currently not possible because the `document.createDocumentFragment` (which depends on the browser) is called on import.

The change ensures that the `document.createDocumentFragment` is only called when needed; which happens in the mounted phase in the browser.